### PR TITLE
Change from getMessage to getFormattedMessage as default

### DIFF
--- a/src/main/java/net/logstash/logback/EventFormatter.java
+++ b/src/main/java/net/logstash/logback/EventFormatter.java
@@ -44,7 +44,7 @@ public class EventFormatter {
     private StackTraceElementProxy[] stackTraceElementProxy;
 
     public EventFormatter(ILoggingEvent loggingEvent) {
-        message = loggingEvent.getMessage();
+        message = loggingEvent.getFormattedMessage();
         timestamp = dateFormat(loggingEvent.getTimeStamp());
         sourceHost = new HostData().getHostName();
 

--- a/src/test/java/net/logstash/logback/JSONEventLayoutV1Test.java
+++ b/src/test/java/net/logstash/logback/JSONEventLayoutV1Test.java
@@ -17,6 +17,7 @@ import org.slf4j.MDC;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.Map;
 
 
 public class JSONEventLayoutV1Test {
@@ -222,4 +223,14 @@ public class JSONEventLayoutV1Test {
         System.clearProperty(JSONEventLayoutV1.ADDITIONAL_DATA_PROPERTY);
 
     }
+
+    @Test
+    public void testMessageWithArguments() {
+        logger.info("Test12: This is a message with {}", "arguments");
+        String message = appender.getMessages()[0];
+
+        Assert.assertTrue("Event is not valid JSON", JSONValue.isValidJsonStrict(message));
+        Assert.assertEquals("Test12: This is a message with arguments", ((Map)JSONValue.parse(message)).get("message"));
+    }
+
 }


### PR DESCRIPTION
To be able to support this kind of logging structure:
 logger.info("Hello {}", "World");

"getMessage" will only return "Hello {}" but
"getFormattedMessage" will return "Hello World".